### PR TITLE
refactor(middleware): move `AuthRequiredMiddleware` from inside auth module into  middleware package

### DIFF
--- a/api/internal/middleware/auth.go
+++ b/api/internal/middleware/auth.go
@@ -1,4 +1,4 @@
-package auth
+package middleware
 
 import (
 	"context"
@@ -10,7 +10,7 @@ import (
 )
 
 func customClaimsConstructor(ctx context.Context) any {
-	return identity.CustomSessionClaims{}
+	return &identity.CustomSessionClaims{}
 }
 
 func withCustomClaimsConstructor(params *clerkHttp.AuthorizationParams) error {

--- a/api/internal/routes/routes.go
+++ b/api/internal/routes/routes.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/deveasyclick/openb2b/docs"
-	"github.com/deveasyclick/openb2b/internal/modules/auth"
+	"github.com/deveasyclick/openb2b/internal/middleware"
 	"github.com/deveasyclick/openb2b/internal/modules/clerk"
 	"github.com/deveasyclick/openb2b/internal/modules/org"
 	"github.com/deveasyclick/openb2b/internal/modules/user"
@@ -65,7 +65,7 @@ func Register(r chi.Router, appCtx *deps.AppContext) {
 
 		// Private routes
 		r.Group(func(r chi.Router) {
-			r.Use(auth.AuthRequiredMiddleware())
+			r.Use(middleware.AuthRequiredMiddleware())
 			registerOrgRoutes(r, orgHandler)
 			registerUserRoutes(r, userHandler)
 		})


### PR DESCRIPTION
refactor(middleware): move `AuthRequiredMiddleware` from inside auth module into  middleware package

This is done to put middlewares in the same package and auth middleware is the only file inside auth module