### PR TITLE
Feat/product error response

### DIFF
--- a/api/internal/shared/response/response.go
+++ b/api/internal/shared/response/response.go
@@ -38,28 +38,18 @@ func WriteJSONError(w http.ResponseWriter, err *apperrors.APIError, logger inter
 	}
 }
 
-func WriteInternalError(w http.ResponseWriter, err error, msg string, logger interfaces.Logger) {
-	logger.Error(msg, "err", err.Error())
-
-	w.WriteHeader(http.StatusInternalServerError)
-	apiError := apperrors.APIError{
-		Code:        http.StatusInternalServerError,
-		Message:     msg,
-		InternalMsg: err.Error(),
+func WriteJSONErrorV2(w http.ResponseWriter, code int, internalError error, msg string, logger interfaces.Logger) {
+	if code == http.StatusInternalServerError {
+		logger.Error(msg, "err", internalError.Error())
 	}
-	if encodeErr := json.NewEncoder(w).Encode(apiError.ToResponse()); encodeErr != nil {
-		logger.Error("failed to encode API error response", "err", encodeErr)
-	}
-}
 
-func WriteBadRequestError(w http.ResponseWriter, err error, logger interfaces.Logger) {
-
-	w.WriteHeader(http.StatusBadRequest)
-	apiError := apperrors.APIError{
-		Code:    http.StatusBadRequest,
-		Message: err.Error(),
+	w.WriteHeader(code)
+	apiError := apperrors.APIErrorResponse{
+		Code:    code,
+		Message: msg,
 	}
-	if encodeErr := json.NewEncoder(w).Encode(apiError.ToResponse()); encodeErr != nil {
+
+	if encodeErr := json.NewEncoder(w).Encode(apiError); encodeErr != nil {
 		logger.Error("failed to encode API error response", "err", encodeErr)
 	}
 }

--- a/makefile
+++ b/makefile
@@ -75,4 +75,4 @@ swagger:
 
 .PHONY: test
 test:
-	cd api && go test ./... | grep -v 'no test files'
+	cd api && go test -count=1 ./... | grep -v 'no test files'


### PR DESCRIPTION
# Update product error handling, response helper and test command

## Changelog

### feat(response)
- Add `WriteJSONErrorV2` function for writing error responses.
- Simplifies error response by accepting error code, error, and message directly instead of requiring an `APIError` struct.

### feat(product)
- Update Product handler to use `WriteJSONErrorV2`.
- Improves error handling consistency in API responses.

### feat(makefile)
- Update `make test` command to include `-count=1` flag.
- Ensures tests are run fresh every time, preventing Go test caching issues.
