### PR TITLE
Fix/order update

### DIFF
--- a/api/internal/modules/order/handler.go
+++ b/api/internal/modules/order/handler.go
@@ -140,7 +140,7 @@ func (h *OrderHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get existing order
-	existingOrder, err := h.service.FindByID(ctx, uint(id))
+	existingOrder, err := h.service.FindOneWithFields(ctx, nil, map[string]any{"id": id}, []string{"Items"})
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			response.WriteJSONErrorV2(w, http.StatusNotFound, nil, apperrors.ErrOrderNotFound, h.appCtx.Logger)

--- a/api/test/integration/order/order_test.go
+++ b/api/test/integration/order/order_test.go
@@ -216,7 +216,7 @@ func TestOrderHandlers(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, order.Data.Notes, "This is a note")
 		assert.Equal(t, order.Data.OrderNumber, "ORD-123")
-		assert.Empty(t, order.Data.Items)
+		assert.Equal(t, len(order.Data.Items), 2)
 	})
 
 	t.Run("Update order - (duplicate order items) success", func(t *testing.T) {


### PR DESCRIPTION
### PR Title  
Refactor discount calculation to use `switch` for improved readability  

---

### Description  
This PR refactors the discount calculation logic in `calculateTotals` to use a `switch` statement instead of multiple `if`/`else if` conditions.  

Using a `switch` improves code clarity, makes it easier to add new discount types in the future, and provides an explicit `default` case for handling unexpected discount types.  

---

### Changes  
- Replaced `if`/`else if` logic for `DiscountType` with a `switch` statement.  
- Added a `default` case to explicitly handle unknown discount types.  
- Improved readability and maintainability of the `calculateTotals` function.  

---

### Why  
This change makes the discount calculation logic cleaner, more idiomatic in Go, and easier to extend without risking nested condition complexity.  